### PR TITLE
Use system environment when {:system, ...} is set

### DIFF
--- a/lib/exquickbooks.ex
+++ b/lib/exquickbooks.ex
@@ -84,10 +84,14 @@ defmodule ExQuickBooks do
   end
 
   defp raise_missing(key) do
-    raise "ExQuickBooks configuration value '#{key}' is required."
+    raise ArgumentError, message: """
+    ExQuickBooks config #{inspect(key)} is required.
+    """
   end
 
   defp raise_invalid(key, value) do
-    raise "ExQuickBooks configuration value '#{key}' is invalid, got: #{value}"
+    raise ArgumentError, message: """
+    ExQuickBooks config #{inspect(key)} is invalid, got: #{inspect(value)}
+    """
   end
 end

--- a/test/exquickbooks_test.exs
+++ b/test/exquickbooks_test.exs
@@ -50,14 +50,14 @@ defmodule ExQuickBooksTest do
     delete_env :consumer_key
     delete_env :consumer_secret
 
-    assert_raise RuntimeError, &ExQuickBooks.credentials/0
+    assert_raise ArgumentError, &ExQuickBooks.credentials/0
   end
 
   test "credentials/0 raises for invalid credentials" do
     put_env :consumer_key, 42
     put_env :consumer_secret, 42
 
-    assert_raise RuntimeError, &ExQuickBooks.credentials/0
+    assert_raise ArgumentError, &ExQuickBooks.credentials/0
   end
 
   test "{:system, ...} syntax is supported" do

--- a/test/exquickbooks_test.exs
+++ b/test/exquickbooks_test.exs
@@ -5,9 +5,11 @@ defmodule ExQuickBooksTest do
 
   setup do
     old_env = get_all_env()
+    old_system_env = System.get_env
 
     on_exit fn ->
       restore_env(old_env)
+      restore_system_env(old_system_env)
     end
   end
 
@@ -16,14 +18,14 @@ defmodule ExQuickBooksTest do
   end
 
   test "accounting_api/0 returns the sandbox URL by default" do
-    delete_env(:use_production_api)
+    delete_env :use_production_api
 
     assert ExQuickBooks.accounting_api |> String.starts_with?("https")
     assert ExQuickBooks.accounting_api |> String.contains?("sandbox")
   end
 
   test "accounting_api/0 returns the production URL in production" do
-    put_env(:use_production_api, true)
+    put_env :use_production_api, true
 
     assert ExQuickBooks.accounting_api |> String.starts_with?("https")
     refute ExQuickBooks.accounting_api |> String.contains?("sandbox")
@@ -35,8 +37,8 @@ defmodule ExQuickBooksTest do
   end
 
   test "credentials/0 returns the right credentials" do
-    put_env(:consumer_key, "key")
-    put_env(:consumer_secret, "secret")
+    put_env :consumer_key, "key"
+    put_env :consumer_secret, "secret"
 
     assert ExQuickBooks.credentials == [
       consumer_key: "key",
@@ -45,17 +47,37 @@ defmodule ExQuickBooksTest do
   end
 
   test "credentials/0 raises for missing credentials" do
-    delete_env(:consumer_key)
-    delete_env(:consumer_secret)
+    delete_env :consumer_key
+    delete_env :consumer_secret
 
     assert_raise RuntimeError, &ExQuickBooks.credentials/0
   end
 
   test "credentials/0 raises for invalid credentials" do
-    put_env(:consumer_key, 42)
-    put_env(:consumer_secret, 42)
+    put_env :consumer_key, 42
+    put_env :consumer_secret, 42
 
     assert_raise RuntimeError, &ExQuickBooks.credentials/0
+  end
+
+  test "{:system, ...} syntax is supported" do
+    System.put_env %{
+      "EXQUICKBOOKS_KEY" => "system_key",
+      "EXQUICKBOOKS_SECRET" => "system_secret",
+      "EXQUICKBOOKS_USE_PRODUCTION_API" => "true"
+    }
+
+    put_env :consumer_key, {:system, "EXQUICKBOOKS_KEY"}
+    put_env :consumer_secret, {:system, "EXQUICKBOOKS_SECRET"}
+    put_env :use_production_api, {:system, "EXQUICKBOOKS_USE_PRODUCTION_API"}
+
+    assert ExQuickBooks.credentials == [
+      consumer_key: "system_key",
+      consumer_secret: "system_secret"
+    ]
+
+    # Production config flag should be parsed as a boolean
+    refute ExQuickBooks.accounting_api |> String.contains?("sandbox")
   end
 
   defp get_all_env do
@@ -79,6 +101,19 @@ defmodule ExQuickBooksTest do
     get_all_env() == old_env || raise """
     Could not restore the application's environment. Check that you're not
     modifying it simultaneously in other tests. Those tests should specify
+    `async: false`.
+    """
+  end
+
+  defp restore_system_env(old_env) do
+    new_env = System.get_env
+
+    for {k, _} <- new_env, do: System.delete_env(k)
+    for {k, v} <- old_env, do: System.put_env(k, v)
+
+    System.get_env == old_env || raise """
+    Could not restore the system's environment. Check that you're not modifying
+    it simultaneously in other tests. Those tests should specify
     `async: false`.
     """
   end


### PR DESCRIPTION
@stavro 

I don’t think we need to read anything else from the system environment other than keys and flags so I only added special case handling for booleans.